### PR TITLE
SpriteKit scene is no longer flickering when TIE Fighter apears.

### DIFF
--- a/Classes/Force.m
+++ b/Classes/Force.m
@@ -43,7 +43,7 @@
     NSInteger startTime = arc4random_uniform(5) + 5;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(startTime * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         TieFighter *tieFighter = [TieFighter new];
-        [[UIApplication sharedApplication].keyWindow.rootViewController.view addSubview:tieFighter];
+        [[UIApplication sharedApplication].keyWindow addSubview:tieFighter];
         [tieFighter flight];
         NSInteger startTime = arc4random_uniform(10) + 5;
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(startTime * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{


### PR DESCRIPTION
TIE Fighter no longer interferes with rootViewController's view chierarchy. As result SKView (which was in my case rootViewController's main view) does not flicker.
